### PR TITLE
Fix typo in CPU generation description

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@
 
    | **Component**  | **Supported**                                                                                       |
    |----------------|-----------------------------------------------------------------------------------------------------|
-   | **CPU**        | Intel: Nehalem and Westmere (1nd Gen) → Arrow Lake (15th Gen/Core Ultra Series 2) <br> AMD: Ryzen and Threadripper with [AMD Vanilla](https://github.com/AMD-OSX/AMD_Vanilla) |
+   | **CPU**        | Intel: Nehalem and Westmere (1st Gen) → Arrow Lake (15th Gen/Core Ultra Series 2) <br> AMD: Ryzen and Threadripper with [AMD Vanilla](https://github.com/AMD-OSX/AMD_Vanilla) |
    | **GPU**        | Intel iGPU: Iron Lake (1nd Gen) → Ice Lake (10th Gen) <br> AMD APU: The entire Vega Raven ASIC family (Ryzen 1xxx → 5xxx, 7x30 series) <br> AMD dGPU: Navi 23, Navi 22, Navi 21 generations, and older series <br> NVIDIA: Kepler, Pascal, Maxwell, Fermi, Tesla generations |
    | **macOS**      | macOS High Sierra → macOS Tahoe |
 


### PR DESCRIPTION
Changed "1nd" to "1st"