### PR TITLE
Map IntelBluetooth asset names to IntelBluetoothFirmware

### DIFF
--- a/Scripts/github.py
+++ b/Scripts/github.py
@@ -136,6 +136,8 @@ class Github:
 
         if "Sniffer" in file_name:
             asset_name = file_name.split(".")[0]
+        if asset_name == "IntelBluetooth":
+            asset_name = "IntelBluetoothFirmware"
         if "unsupported" in file_name:
             asset_name += "-unsupported"
         elif "rtsx" in file_name:


### PR DESCRIPTION
This pull request introduces a minor fix to the asset name extraction logic in the `extract_asset_name` function within `Scripts/github.py`. The change ensures that files named `IntelBluetooth` are correctly mapped to the asset name `IntelBluetoothFirmware`.

* Asset name mapping: Updated the logic in `extract_asset_name` to map `IntelBluetooth` to `IntelBluetoothFirmware`, ensuring consistent asset naming for Bluetooth-related files.

currently in the console log:
```bash
⚠ Could not find download URL for IntelBluetoothFirmware
⚠ Could not find download URL for IntelBluetoothFirmware
```