### PR TITLE
fix: accept valid non-_SB ACPI paths in report validation

### DIFF
--- a/Scripts/report_validator.py
+++ b/Scripts/report_validator.py
@@ -21,7 +21,7 @@ class ReportValidator:
             "device_id": r"^[0-9A-F]{4}(?:-[0-9A-F]{4})?$",
             "resolution": r"^\d+x\d+$",
             "pci_path": r"^PciRoot\(0x[0-9a-fA-F]+\)(?:/Pci\(0x[0-9a-fA-F]+,0x[0-9a-fA-F]+\))+$",
-            "acpi_path": r"^[\\]?_SB(\.[A-Z0-9_]+)+$",
+            "acpi_path": r"^[\\]?(_SB|_TZ_|[A-Z0-9_]+)(\.[A-Z0-9_]+)*$",
             "core_count": r"^\d+$",
             "connector_type": r"^(VGA|DVI|HDMI|LVDS|DP|eDP|Internal|Uninitialized)$",
             "enabled_disabled": r"^(Enabled|Disabled)$"


### PR DESCRIPTION
## Summary

`Scripts/report_validator.py:24` only accepted `_SB`-rooted ACPI paths:

```python
r"^[\\]?_SB(\.[A-Z0-9_]+)+$"
```

Reports exported by Hardware Sniffer on **Linux** include System Devices with perfectly valid ACPI paths outside `_SB` (see #681):

- `\_TZ_.TZS0` – thermal zone
- `\_TZ_.FAN0` – fan under the thermal zone
- `\AOD_` – root-level device (AMD)

The validator flagged these as errors and OpCore Simplify refused the report, blocking the entire Linux workflow.

## Changes

```python
r"^[\\]?(_SB|_TZ_|[A-Z0-9_]+)(\.[A-Z0-9_]+)*$"
```

Accepts any syntactically valid ACPI path: optional root `\`, a root scope or device (`_SB`, `_TZ_`, or root-level devices like `AOD_`), followed by optional `.Name` segments.

## Verification

Validated against a full Linux report with 61 ACPI paths — all pass with the new pattern, exactly the 3 previously-rejected paths differ from the old pattern.

Closes #681