### PR TITLE
Fix broken Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,4 +168,4 @@ Distributed under the BSD 3-Clause License. See `LICENSE` for more information.
 
 ## 🌟 **Star History**
 
-[![Star History Chart](https://api.star-history.com/svg?repos=lzhoang2801/OpCore-Simplify&type=Date)](https://star-history.com/#lzhoang2801/OpCore-Simplify&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=lzhoang2801/OpCore-Simplify&type=Date)](https://star-history.dera.page/#lzhoang2801/OpCore-Simplify&Date)


### PR DESCRIPTION
The Star History chart in the README is currently broken because of GitHub stargazer API restrictions. This update switches the chart to the new star-history.dera.page domain, which uses an alternative data source that requires no API token, restoring the chart's functionality.